### PR TITLE
Add install script to simplify setup for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,18 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+## 📂 FOIA Archive: DOJ Release
 
-## Getting Started
+> [!NOTE]
 
-First, run the development server:
+On December 20, 2025, the U.S Government released a significant volume of files and images related to the Epstein case via the Department of Justice (DOJ) website. Due to extreme public interest, the official government servers are currently experiencing high latency and intermittent downtime.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+This repository serves as a high-performance mirror and development toolkit to ensure the public has stable, fast access to these documents.
+
+## Run the Setup
+Simply run the following command in your terminal to prepare your environment and start the dev server:
+
+```sh
+chmod +x run.sh && ./run.sh
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+> [!IMPORTANT]
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+This is a community-maintained mirror. While we strive for 1:1 accuracy with the official DOJ release, always verify critical information against the primary source at [justice.gov](https://www.justice.gov/epstein) once their traffic stabilizes.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
-## 📂 FOIA Archive: DOJ Release
+# 📂 FOIA Archive: DOJ Release
 
 > [!NOTE]
-
 On December 20, 2025, the U.S Government released a significant volume of files and images related to the Epstein case via the Department of Justice (DOJ) website. Due to extreme public interest, the official government servers are currently experiencing high latency and intermittent downtime.
 
 This repository serves as a high-performance mirror and development toolkit to ensure the public has stable, fast access to these documents.
 
 ## Run the Setup
 Simply run the following command in your terminal to prepare your environment and start the dev server:
-
 ```sh
 chmod +x run.sh && ./run.sh
 ```
 
 > [!IMPORTANT]
-
-This is a community-maintained mirror. While we strive for 1:1 accuracy with the official DOJ release, always verify critical information against the primary source at [justice.gov](https://www.justice.gov/epstein) once their traffic stabilizes.
+This is a community-maintained mirror. While we strive for 1:1 accuracy with the official DOJ release, always verify critical information against the primary source at [justice.gov](https://www.justice.gov/epstein) once their traffic stabilizes

--- a/app/file-browser.tsx
+++ b/app/file-browser.tsx
@@ -17,6 +17,7 @@ import {
 import { CelebrityCombobox } from "@/components/celebrity-combobox";
 import { CelebrityDisclaimer } from "@/components/celebrity-disclaimer";
 import { useFiles } from "@/lib/files-context";
+import Link from 'next/link'
 
 const WORKER_URL =
   process.env.NODE_ENV === "development"
@@ -620,9 +621,11 @@ export function FileBrowser() {
           <div className="flex items-center justify-between mb-5">
             <div className="flex items-center gap-3">
               <div>
+                <Link href="/">
                 <h1 className="text-xl sm:text-2xl font-bold text-foreground tracking-tight">
                   Epstein Files Browser
                 </h1>
+                </Link>
               </div>
             </div>
             <a

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+GREEN=$(tput setaf 2)
+YELLOW=$(tput setaf 3)
+RED=$(tput setaf 1)
+BOLD=$(tput bold)
+NC=$(tput sgr0)
+
+
+log_info() {
+    echo -e "${YELLOW}--> $1${NC}"
+}
+
+log_success() {
+    echo -e "${GREEN}${BOLD}✓ $1${NC}"
+}
+
+log_error() {
+    echo -e "${RED}${BOLD}✗ Error: $1${NC}" >&2
+}
+
+show_progress() {
+    local duration=$1
+    local steps=20
+    local sleep_interval
+    sleep_interval=$(echo "$duration / $steps" | awk '{print $1 / $2}')
+
+    for ((i=0; i<=steps; i++)); do
+        local progress=$((i * 100 / steps))
+        local done=$(printf "%${i}s" | tr ' ' '=')
+        local left=$(printf "%$((steps - i))s" | tr ' ' ' ')
+        printf "\r[${done}${left}] %d%%" "$progress"
+        sleep 0.1
+    done
+    echo
+}
+
+execute_step() {
+    local cmd=$1
+    local desc=$2
+
+    log_info "$desc"
+    
+    if eval "$cmd" > /dev/null 2>&1; then
+        show_progress 1
+        log_success "Completed: $desc"
+    else
+        log_error "Failed during: $desc"
+        exit 1
+    fi
+}
+
+main() {
+    clear
+    echo -e "${BOLD}Environment Setup & Update${NC}"
+    echo "--------------------------------"
+
+    execute_step "npm install -g bun" "Installing/Updating Bun runtime..."
+
+    if [[ -f "package.json" ]]; then
+        execute_step "bun update --latest" "Synchronizing dependencies..."
+    else
+        log_error "package.json not found in current directory."
+        exit 1
+    fi
+
+    log_success "Environment is ready for development..."
+    echo ""
+
+    log_info "Launching development server..."
+    bun run dev
+}
+
+main "$@"


### PR DESCRIPTION
- Adds a shell script to automate Bun installation so contributors do not need to manually run `npm i -g bun`,
- Updates the `readme.md` to clarify the repository’s purpose and document the new setup flow.